### PR TITLE
Instruções para instalar o projeto; Atualização das dependências.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # CMPaaS
 Repositório Oficial do Projeto CMPaaS
+
+### Instruções para rodar o projeto
+
+* Baixe os arquivos do repositório
+* Crie um *virtual enviroment* (virtualenv)
+
+```
+python3 -m venv env
+```
+
+* Ative o virtualenv
+
+```
+source env/bin/activate
+```
+
+* Instale as depêndencias
+
+```
+pip install -r requirements.txt
+```
+
+* Rode o servidor
+
+```
+python manage.py runserver
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 Django==1.10.1
+Pillow==3.3.1
 django-braces==1.9.0
+django-cors-headers==1.2.2
 django-oauth-toolkit==0.10.0
 djangorestframework==3.4.7
 oauthlib==1.0.3
-Pillow==3.3.1
 pymongo==3.3.0
 six==1.10.0


### PR DESCRIPTION
Para rodar o projeto é preciso instalar a biblioteca django-cors-headers, porém a mesma não estava no arquivo requirements.txt. Por isso fiz a inclusão.

Além disso, coloquei um passo a passo para rodar o projeto.
